### PR TITLE
patches: fixes codec2json compile error

### DIFF
--- a/patches/0033-codecparsers-av1-delete-the-useless-increment_tile_r.patch
+++ b/patches/0033-codecparsers-av1-delete-the-useless-increment_tile_r.patch
@@ -1,19 +1,33 @@
-From 800e1ba27428b93d74e36f518b0119d1708dc858 Mon Sep 17 00:00:00 2001
+From 446727abecd6b3985373205a991231a2e1120cbd Mon Sep 17 00:00:00 2001
 From: He Junyan <junyan.he@intel.com>
 Date: Tue, 19 Jul 2022 16:27:01 +0800
 Subject: [PATCH 13/20] codecparsers: av1: delete the useless
  increment_tile_rows_log2 in tile info.
 
 ---
+ subprojects/gst-plugins-bad/ext/codec2json/gstav12json.c      | 2 --
  .../gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.c  | 4 ++--
  .../gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.h  | 2 --
- 2 files changed, 2 insertions(+), 4 deletions(-)
+ 3 files changed, 2 insertions(+), 6 deletions(-)
 
+diff --git a/subprojects/gst-plugins-bad/ext/codec2json/gstav12json.c b/subprojects/gst-plugins-bad/ext/codec2json/gstav12json.c
+index 5bc8907eb525..3827a5916b8a 100644
+--- a/subprojects/gst-plugins-bad/ext/codec2json/gstav12json.c
++++ b/subprojects/gst-plugins-bad/ext/codec2json/gstav12json.c
+@@ -498,8 +498,6 @@ gst_av1_2_json_frame_header (GstAV12json * self,
+   tile_info = json_object_new ();
+   json_object_set_int_member (tile_info, "uniform tile spacing flag",
+       frame_header->tile_info.uniform_tile_spacing_flag);
+-  json_object_set_int_member (tile_info, "increment tile rows log2",
+-      frame_header->tile_info.increment_tile_rows_log2);
+   width_in_sbs_minus_1 = json_array_new ();
+   height_in_sbs_minus_1 = json_array_new ();
+   for (i = 0; i < GST_AV1_MAX_TILE_COLS; i++) {
 diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.c b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.c
-index e2876db01f..3178c5d97f 100644
+index 8e9a206f27fc..786cde78e924 100644
 --- a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.c
 +++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.c
-@@ -2263,11 +2263,11 @@ gst_av1_parse_tile_info (GstAV1Parser * parser, GstBitReader * br,
+@@ -2259,11 +2259,11 @@ gst_av1_parse_tile_info (GstAV1Parser * parser, GstBitReader * br,
      min_log2_tile_rows = MAX (min_log2_tiles - parser->state.tile_cols_log2, 0);
      parser->state.tile_rows_log2 = min_log2_tile_rows;
      while (parser->state.tile_rows_log2 < max_log2_tile_rows) {
@@ -28,7 +42,7 @@ index e2876db01f..3178c5d97f 100644
        else
          break;
 diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.h b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.h
-index a5f1c761f6..2c7106dd3e 100644
+index a5f1c761f6fc..2c7106dd3e18 100644
 --- a/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.h
 +++ b/subprojects/gst-plugins-bad/gst-libs/gst/codecparsers/gstav1parser.h
 @@ -1188,7 +1188,6 @@ struct _GstAV1SegmenationParams {
@@ -48,5 +62,5 @@ index a5f1c761f6..2c7106dd3e 100644
    gint height_in_sbs_minus_1[GST_AV1_MAX_TILE_ROWS];
    gint tile_size_bytes_minus_1;
 -- 
-2.25.1
+2.38.1
 


### PR DESCRIPTION
In cartwheel, the GstAV1TileInfo increment_tile_rows_log2 member is removed.  However, recent upstream commit references this member in codec2json plugin.

Remove the member usage in codec2json plugin, too.

Fixes #42